### PR TITLE
Fix z-index problem on dropdown

### DIFF
--- a/public/css/components/dropdown.less
+++ b/public/css/components/dropdown.less
@@ -1,7 +1,7 @@
 .apos-ui-dropdown
 {
   position: relative;
-  z-index: 20;
+  z-index: 900;
   margin-bottom: 10px;
 
   .apos-ui-menu


### PR DESCRIPTION
The buttons on the left and right are defined with z-index of 899. The z-index of 20 here causes a nasty bug discussed here:
https://github.com/punkave/apostrophe-editor-2/issues/22
