### PR TITLE
Draggable admin menus

### DIFF
--- a/public/js/ui-2.js
+++ b/public/js/ui-2.js
@@ -13,4 +13,7 @@ $(function(){
   $('.apos-admin-bar').on('transitionend', function(){
     if(!$(this).hasClass('collapsed')) { $(this).css('overflow', 'visible'); }
   });
+
+  $('.apos-admin-bar').draggable();
+  $('.apos-pages-menu').draggable({ axis: "x"});
 });


### PR DESCRIPTION
When I installed the Apostrophe and tried to run, the admin menus were over the content I created, so I change it to be draggable.
